### PR TITLE
Move scopes to seperate files

### DIFF
--- a/pkg/kubelet/cm/topologymanager/policy.go
+++ b/pkg/kubelet/cm/topologymanager/policy.go
@@ -21,13 +21,6 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
 )
 
-const (
-	// containerTopologyScope specifies the TopologyManagerScope per container.
-	containerTopologyScope = "container"
-	// podTopologyScope specifies the TopologyManagerScope per pod.
-	podTopologyScope = "pod"
-)
-
 // Policy interface for Topology Manager Pod Admit Result
 type Policy interface {
 	// Returns Policy Name

--- a/pkg/kubelet/cm/topologymanager/scope.go
+++ b/pkg/kubelet/cm/topologymanager/scope.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topologymanager
+
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
+)
+
+
+const (
+	// containerTopologyScope specifies the TopologyManagerScope per container.
+	containerTopologyScope = "container"
+	// podTopologyScope specifies the TopologyManagerScope per pod.
+	podTopologyScope = "pod"
+)
+
+type Scope interface {
+	Name() string
+	Admit(pod *v1.Pod) lifecycle.PodAdmitResult
+	AddHintProvider(h HintProvider)
+}
+
+type scope struct {
+	name string
+	podTopologyHints *PodTopologyHints
+	hintProviders []HintProvider
+	policy Policy
+}
+
+func (s *scope) Name() string {
+	return s.name
+}
+
+func (s *scope) allocateAlignedResources(pod *v1.Pod, container *v1.Container) error {
+	for _, provider := range s.hintProviders {
+		err := provider.Allocate(pod, container)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *scope) admitPolicyNone(pod *v1.Pod) lifecycle.PodAdmitResult{
+
+	for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
+		err := s.allocateAlignedResources(pod, &container)
+		if err != nil {
+			return unexpectedAdmissionError(err)
+		}
+	}
+	return admitPod()
+}
+
+func (s *scope) AddHintProvider(h HintProvider) {
+	s.hintProviders = append(s.hintProviders, h)
+}

--- a/pkg/kubelet/cm/topologymanager/scope_container.go
+++ b/pkg/kubelet/cm/topologymanager/scope_container.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+package topologymanager
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
+	"k8s.io/kubernetes/pkg/kubelet/util/format"
+)
+
+
+type containerScope struct {
+	scope
+}
+
+// Ensure containerScope implements Scope interface
+var _ Scope = &containerScope{}
+
+func NewContainerScope(podTopologyHints *PodTopologyHints, policy Policy) Scope {
+	return &containerScope{
+		scope{
+			name: containerTopologyScope,
+			podTopologyHints: podTopologyHints,
+			policy: policy,
+		},
+	}
+}
+
+func (s *containerScope) calculateAffinity(pod *v1.Pod, container *v1.Container) (TopologyHint, bool) {
+	providersHints := s.accumulateProvidersHints(pod, container)
+	bestHint, admit := s.policy.Merge(providersHints)
+	klog.Infof("[topologymanager] ContainerTopologyHint: %v", bestHint)
+	return bestHint, admit
+}
+
+
+func (s *containerScope) accumulateProvidersHints(pod *v1.Pod, container *v1.Container) (providersHints []map[string][]TopologyHint) {
+	// Loop through all hint providers and save an accumulated list of the
+	// hints returned by each hint provider.
+	for _, provider := range s.hintProviders {
+		// Get the TopologyHints from a provider.
+		hints := provider.GetTopologyHints(pod, container)
+		providersHints = append(providersHints, hints)
+		klog.Infof("[topologymanager] TopologyHints for pod '%v', container '%v': %v", format.Pod(pod), container.Name, hints)
+	}
+	return providersHints
+}
+
+func (s *containerScope) Admit(pod *v1.Pod) lifecycle.PodAdmitResult{
+	
+	// Exception - Policy : none
+	if s.policy.Name() == PolicyNone {
+		return s.admitPolicyNone(pod)
+	}
+	
+	for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
+		bestHint, admit := s.calculateAffinity(pod, &container)
+
+		if !admit {
+			return topologyAffinityError()
+		}
+
+		if (*s.podTopologyHints)[string(pod.UID)] == nil {
+			(*s.podTopologyHints)[string(pod.UID)] = make(map[string]TopologyHint)
+		}
+
+		klog.Infof("[topologymanager] Topology Affinity for (pod: %v container: %v): %v", format.Pod(pod), container.Name, bestHint)
+		(*s.podTopologyHints)[string(pod.UID)][container.Name]=bestHint
+		err := s.allocateAlignedResources(pod, &container)
+		if err != nil {
+			return unexpectedAdmissionError(err)
+		}
+	}
+	return admitPod()
+}

--- a/pkg/kubelet/cm/topologymanager/scope_container_test.go
+++ b/pkg/kubelet/cm/topologymanager/scope_container_test.go
@@ -1,0 +1,252 @@
+package topologymanager
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestCtnCalculateAffinity(t *testing.T) {
+	tcases := []struct {
+		name     string
+		hp       []HintProvider
+		expected []map[string][]TopologyHint
+	}{
+		{
+			name:     "No hint providers",
+			hp:       []HintProvider{},
+			expected: ([]map[string][]TopologyHint)(nil),
+		},
+		{
+			name: "HintProvider returns empty non-nil map[string][]TopologyHint",
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{},
+				},
+			},
+			expected: []map[string][]TopologyHint{
+				{},
+			},
+		},
+		{
+			name: "HintProvider returns -nil map[string][]TopologyHint from provider",
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource": nil,
+					},
+				},
+			},
+			expected: []map[string][]TopologyHint{
+				{
+					"resource": nil,
+				},
+			},
+		},
+		{
+			name: "Assorted HintProviders",
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource-1/A": {
+							{NUMANodeAffinity: NewTestBitMask(0), Preferred: true},
+							{NUMANodeAffinity: NewTestBitMask(0, 1), Preferred: false},
+						},
+						"resource-1/B": {
+							{NUMANodeAffinity: NewTestBitMask(1), Preferred: true},
+							{NUMANodeAffinity: NewTestBitMask(1, 2), Preferred: false},
+						},
+					},
+				},
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource-2/A": {
+							{NUMANodeAffinity: NewTestBitMask(2), Preferred: true},
+							{NUMANodeAffinity: NewTestBitMask(3, 4), Preferred: false},
+						},
+						"resource-2/B": {
+							{NUMANodeAffinity: NewTestBitMask(2), Preferred: true},
+							{NUMANodeAffinity: NewTestBitMask(3, 4), Preferred: false},
+						},
+					},
+				},
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource-3": nil,
+					},
+				},
+			},
+			expected: []map[string][]TopologyHint{
+				{
+					"resource-1/A": {
+						{NUMANodeAffinity: NewTestBitMask(0), Preferred: true},
+						{NUMANodeAffinity: NewTestBitMask(0, 1), Preferred: false},
+					},
+					"resource-1/B": {
+						{NUMANodeAffinity: NewTestBitMask(1), Preferred: true},
+						{NUMANodeAffinity: NewTestBitMask(1, 2), Preferred: false},
+					},
+				},
+				{
+					"resource-2/A": {
+						{NUMANodeAffinity: NewTestBitMask(2), Preferred: true},
+						{NUMANodeAffinity: NewTestBitMask(3, 4), Preferred: false},
+					},
+					"resource-2/B": {
+						{NUMANodeAffinity: NewTestBitMask(2), Preferred: true},
+						{NUMANodeAffinity: NewTestBitMask(3, 4), Preferred: false},
+					},
+				},
+				{
+					"resource-3": nil,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tcases {
+		ctnScope := &containerScope{
+			scope{
+				hintProviders: tc.hp,
+				policy:        &mockPolicy{},
+				name:          podTopologyScope,
+			},
+		}
+
+		ctnScope.calculateAffinity(&v1.Pod{}, &v1.Container{})
+		actual := ctnScope.policy.(*mockPolicy).ph
+		if !reflect.DeepEqual(tc.expected, actual) {
+			t.Errorf("Test Case: %s", tc.name)
+			t.Errorf("Expected result to be %v, got %v", tc.expected, actual)
+		}
+	}
+}
+
+func TestCtnAccumulateProvidersHints(t *testing.T) {
+	tcases := []struct {
+		name     string
+		hp       []HintProvider
+		expected []map[string][]TopologyHint
+	}{
+		{
+			name:     "TopologyHint not set",
+			hp:       []HintProvider{},
+			expected: nil,
+		},
+		{
+			name: "HintProvider returns empty non-nil map[string][]TopologyHint",
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{},
+				},
+			},
+			expected: []map[string][]TopologyHint{
+				{},
+			},
+		},
+		{
+			name: "HintProvider returns - nil map[string][]TopologyHint from provider",
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource": nil,
+					},
+				},
+			},
+			expected: []map[string][]TopologyHint{
+				{
+					"resource": nil,
+				},
+			},
+		},
+		{
+			name: "2 HintProviders with 1 resource returns hints",
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource1": {TopologyHint{}},
+					},
+				},
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource2": {TopologyHint{}},
+					},
+				},
+			},
+			expected: []map[string][]TopologyHint{
+				{
+					"resource1": {TopologyHint{}},
+				},
+				{
+					"resource2": {TopologyHint{}},
+				},
+			},
+		},
+		{
+			name: "2 HintProviders 1 with 1 resource 1 with nil hints",
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource1": {TopologyHint{}},
+					},
+				},
+				&mockHintProvider{nil},
+			},
+			expected: []map[string][]TopologyHint{
+				{
+					"resource1": {TopologyHint{}},
+				},
+				nil,
+			},
+		},
+		{
+			name: "2 HintProviders 1 with 1 resource 1 empty hints",
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource1": {TopologyHint{}},
+					},
+				},
+				&mockHintProvider{
+					map[string][]TopologyHint{},
+				},
+			},
+			expected: []map[string][]TopologyHint{
+				{
+					"resource1": {TopologyHint{}},
+				},
+				{},
+			},
+		},
+		{
+			name: "HintProvider with 2 resources returns hints",
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource1": {TopologyHint{}},
+						"resource2": {TopologyHint{}},
+					},
+				},
+			},
+			expected: []map[string][]TopologyHint{
+				{
+					"resource1": {TopologyHint{}},
+					"resource2": {TopologyHint{}},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tcases {
+		ctnScope := containerScope{
+			scope{
+				hintProviders: tc.hp,
+			},
+		}
+		actual := ctnScope.accumulateProvidersHints(&v1.Pod{}, &v1.Container{})
+		if !reflect.DeepEqual(actual, tc.expected) {
+			t.Errorf("Test Case %s: Expected NUMANodeAffinity in result to be %v, got %v", tc.name, tc.expected, actual)
+		}
+	}
+}

--- a/pkg/kubelet/cm/topologymanager/scope_pod.go
+++ b/pkg/kubelet/cm/topologymanager/scope_pod.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+
+package topologymanager
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
+	"k8s.io/kubernetes/pkg/kubelet/util/format"
+)
+
+type podScope struct {
+	scope
+}
+
+// Ensure podScope implements Scope interface
+var _ Scope = &podScope{}
+
+func NewPodScope(podTopologyHints *PodTopologyHints, policy Policy) Scope {
+	return &podScope{
+		scope{
+			name: podTopologyScope,
+			podTopologyHints: podTopologyHints,
+			policy: policy,
+		},
+	}
+}
+
+func (s *podScope) Admit(pod *v1.Pod) lifecycle.PodAdmitResult{
+	
+	// Exception - Policy : none
+	if s.policy.Name() == PolicyNone {
+		return s.admitPolicyNone(pod)
+	}
+
+	bestHint, admit := s.calculateAffinity(pod)
+	klog.Infof("[topologymanager] Best TopologyHint for pod : %v", bestHint)
+	if !admit {
+		return topologyAffinityError()
+	}
+	
+	for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
+		klog.Infof("[topologymanager] Topology Affinity for (pod: %v container: %v): %v", format.Pod(pod), container.Name, bestHint)
+		
+		if (*s.podTopologyHints)[string(pod.UID)] == nil {
+			(*s.podTopologyHints)[string(pod.UID)] = make(map[string]TopologyHint)
+		}
+		
+		(*s.podTopologyHints)[string(pod.UID)][container.Name]=bestHint
+				
+		err := s.allocateAlignedResources(pod, &container)
+		if err != nil {
+			return unexpectedAdmissionError(err)
+		}
+	}
+	return admitPod()
+}
+
+func (s *podScope) accumulateProvidersHints(pod *v1.Pod) (providersHints []map[string][]TopologyHint){
+	for _, provider := range s.hintProviders {
+		// Get the TopologyHints for a Pod from a provider.
+		hints := provider.GetPodTopologyHints(pod)
+		providersHints = append(providersHints, hints) 
+		klog.Infof("[topologymanager] TopologyHints for pod '%v': %v", format.Pod(pod), hints)
+	}
+	return providersHints
+}
+
+func (s *podScope) calculateAffinity(pod *v1.Pod) (TopologyHint, bool) {
+	providersHints := s.accumulateProvidersHints(pod)
+	bestHint, admit := s.policy.Merge(providersHints)
+	klog.Infof("[topologymanager] PodTopologyHint: %v", bestHint)
+	return bestHint, admit
+}

--- a/pkg/kubelet/cm/topologymanager/scope_pod_test.go
+++ b/pkg/kubelet/cm/topologymanager/scope_pod_test.go
@@ -1,0 +1,252 @@
+package topologymanager
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestPodCalculateAffinity(t *testing.T) {
+	tcases := []struct {
+		name     string
+		hp       []HintProvider
+		expected []map[string][]TopologyHint
+	}{
+		{
+			name:     "No hint providers",
+			hp:       []HintProvider{},
+			expected: ([]map[string][]TopologyHint)(nil),
+		},
+		{
+			name: "HintProvider returns empty non-nil map[string][]TopologyHint",
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{},
+				},
+			},
+			expected: []map[string][]TopologyHint{
+				{},
+			},
+		},
+		{
+			name: "HintProvider returns -nil map[string][]TopologyHint from provider",
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource": nil,
+					},
+				},
+			},
+			expected: []map[string][]TopologyHint{
+				{
+					"resource": nil,
+				},
+			},
+		},
+		{
+			name: "Assorted HintProviders",
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource-1/A": {
+							{NUMANodeAffinity: NewTestBitMask(0), Preferred: true},
+							{NUMANodeAffinity: NewTestBitMask(0, 1), Preferred: false},
+						},
+						"resource-1/B": {
+							{NUMANodeAffinity: NewTestBitMask(1), Preferred: true},
+							{NUMANodeAffinity: NewTestBitMask(1, 2), Preferred: false},
+						},
+					},
+				},
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource-2/A": {
+							{NUMANodeAffinity: NewTestBitMask(2), Preferred: true},
+							{NUMANodeAffinity: NewTestBitMask(3, 4), Preferred: false},
+						},
+						"resource-2/B": {
+							{NUMANodeAffinity: NewTestBitMask(2), Preferred: true},
+							{NUMANodeAffinity: NewTestBitMask(3, 4), Preferred: false},
+						},
+					},
+				},
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource-3": nil,
+					},
+				},
+			},
+			expected: []map[string][]TopologyHint{
+				{
+					"resource-1/A": {
+						{NUMANodeAffinity: NewTestBitMask(0), Preferred: true},
+						{NUMANodeAffinity: NewTestBitMask(0, 1), Preferred: false},
+					},
+					"resource-1/B": {
+						{NUMANodeAffinity: NewTestBitMask(1), Preferred: true},
+						{NUMANodeAffinity: NewTestBitMask(1, 2), Preferred: false},
+					},
+				},
+				{
+					"resource-2/A": {
+						{NUMANodeAffinity: NewTestBitMask(2), Preferred: true},
+						{NUMANodeAffinity: NewTestBitMask(3, 4), Preferred: false},
+					},
+					"resource-2/B": {
+						{NUMANodeAffinity: NewTestBitMask(2), Preferred: true},
+						{NUMANodeAffinity: NewTestBitMask(3, 4), Preferred: false},
+					},
+				},
+				{
+					"resource-3": nil,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tcases {
+		podScope := &podScope{
+			scope{
+				hintProviders: tc.hp,
+				policy:        &mockPolicy{},
+				name:          podTopologyScope,
+			},
+		}
+
+		podScope.calculateAffinity(&v1.Pod{})
+		actual := podScope.policy.(*mockPolicy).ph
+		if !reflect.DeepEqual(tc.expected, actual) {
+			t.Errorf("Test Case: %s", tc.name)
+			t.Errorf("Expected result to be %v, got %v", tc.expected, actual)
+		}
+	}
+}
+
+func TestPodAccumulateProvidersHints(t *testing.T) {
+	tcases := []struct {
+		name     string
+		hp       []HintProvider
+		expected []map[string][]TopologyHint
+	}{
+		{
+			name:     "TopologyHint not set",
+			hp:       []HintProvider{},
+			expected: nil,
+		},
+		{
+			name: "HintProvider returns empty non-nil map[string][]TopologyHint",
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{},
+				},
+			},
+			expected: []map[string][]TopologyHint{
+				{},
+			},
+		},
+		{
+			name: "HintProvider returns - nil map[string][]TopologyHint from provider",
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource": nil,
+					},
+				},
+			},
+			expected: []map[string][]TopologyHint{
+				{
+					"resource": nil,
+				},
+			},
+		},
+		{
+			name: "2 HintProviders with 1 resource returns hints",
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource1": {TopologyHint{}},
+					},
+				},
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource2": {TopologyHint{}},
+					},
+				},
+			},
+			expected: []map[string][]TopologyHint{
+				{
+					"resource1": {TopologyHint{}},
+				},
+				{
+					"resource2": {TopologyHint{}},
+				},
+			},
+		},
+		{
+			name: "2 HintProviders 1 with 1 resource 1 with nil hints",
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource1": {TopologyHint{}},
+					},
+				},
+				&mockHintProvider{nil},
+			},
+			expected: []map[string][]TopologyHint{
+				{
+					"resource1": {TopologyHint{}},
+				},
+				nil,
+			},
+		},
+		{
+			name: "2 HintProviders 1 with 1 resource 1 empty hints",
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource1": {TopologyHint{}},
+					},
+				},
+				&mockHintProvider{
+					map[string][]TopologyHint{},
+				},
+			},
+			expected: []map[string][]TopologyHint{
+				{
+					"resource1": {TopologyHint{}},
+				},
+				{},
+			},
+		},
+		{
+			name: "HintProvider with 2 resources returns hints",
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource1": {TopologyHint{}},
+						"resource2": {TopologyHint{}},
+					},
+				},
+			},
+			expected: []map[string][]TopologyHint{
+				{
+					"resource1": {TopologyHint{}},
+					"resource2": {TopologyHint{}},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tcases {
+		pScope := podScope{
+			scope{
+				hintProviders: tc.hp,
+			},
+		}
+		actual := pScope.accumulateProvidersHints(&v1.Pod{})
+		if !reflect.DeepEqual(actual, tc.expected) {
+			t.Errorf("Test Case %s: Expected NUMANodeAffinity in result to be %v, got %v", tc.name, tc.expected, actual)
+		}
+	}
+}

--- a/pkg/kubelet/cm/topologymanager/scope_test.go
+++ b/pkg/kubelet/cm/topologymanager/scope_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,24 +17,13 @@ limitations under the License.
 package topologymanager
 
 import (
+	"k8s.io/api/core/v1"
 	"reflect"
 	"testing"
-
-	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 )
 
-func TestNewFakeManager(t *testing.T) {
-	fm := NewFakeManager()
-
-	if _, ok := fm.(Manager); !ok {
-		t.Errorf("Result is not Manager type")
-
-	}
-}
-
-func TestFakeGetAffinity(t *testing.T) {
+func TestGetAffinity(t *testing.T) {
 	tcases := []struct {
 		name          string
 		containerName string
@@ -42,22 +31,22 @@ func TestFakeGetAffinity(t *testing.T) {
 		expected      TopologyHint
 	}{
 		{
-			name:          "Case1",
+			name:          "case1",
 			containerName: "nginx",
 			podUID:        "0aafa4c4-38e8-11e9-bcb1-a4bf01040474",
 			expected:      TopologyHint{},
 		},
 	}
 	for _, tc := range tcases {
-		fm := fakeManager{}
-		actual := fm.GetAffinity(tc.podUID, tc.containerName)
+		scope := scope{}
+		actual := scope.GetAffinity(tc.podUID, tc.containerName)
 		if !reflect.DeepEqual(actual, tc.expected) {
 			t.Errorf("Expected Affinity in result to be %v, got %v", tc.expected, actual)
 		}
 	}
 }
 
-func TestFakeAddContainer(t *testing.T) {
+func TestAddContainer(t *testing.T) {
 	testCases := []struct {
 		name        string
 		containerID string
@@ -74,26 +63,30 @@ func TestFakeAddContainer(t *testing.T) {
 			podUID:      "b3ee37fc-39a5-11e9-bcb1-a4bf01040474",
 		},
 	}
-	fm := fakeManager{}
-	mngr := manager{}
-	mngr.podMap = make(map[string]string)
+	scope := scope{}
+	scope.podMap = make(map[string]string)
 	for _, tc := range testCases {
 		pod := v1.Pod{}
 		pod.UID = tc.podUID
-		err := fm.AddContainer(&pod, tc.containerID)
+		err := scope.AddContainer(&pod, tc.containerID)
 		if err != nil {
 			t.Errorf("Expected error to be nil but got: %v", err)
-
 		}
-
+		if val, ok := scope.podMap[tc.containerID]; ok {
+			if reflect.DeepEqual(val, pod.UID) {
+				t.Errorf("Error occurred")
+			}
+		} else {
+			t.Errorf("Error occurred, Pod not added to podMap")
+		}
 	}
 }
 
-func TestFakeRemoveContainer(t *testing.T) {
+func TestRemoveContainer(t *testing.T) {
 	testCases := []struct {
 		name        string
 		containerID string
-		podUID      string
+		podUID      types.UID
 	}{
 		{
 			name:        "Case1",
@@ -106,54 +99,20 @@ func TestFakeRemoveContainer(t *testing.T) {
 			podUID:      "b3ee37fc-39a5-11e9-bcb1-a4bf01040474",
 		},
 	}
-	fm := fakeManager{}
-	mngr := manager{}
-	mngr.podMap = make(map[string]string)
+	var len1, len2 int
+	scope := scope{}
+	scope.podMap = make(map[string]string)
 	for _, tc := range testCases {
-		err := fm.RemoveContainer(tc.containerID)
+		scope.podMap[tc.containerID] = string(tc.podUID)
+		len1 = len(scope.podMap)
+		err := scope.RemoveContainer(tc.containerID)
+		len2 = len(scope.podMap)
 		if err != nil {
 			t.Errorf("Expected error to be nil but got: %v", err)
 		}
-
-	}
-
-}
-
-func TestFakeAdmit(t *testing.T) {
-	tcases := []struct {
-		name     string
-		result   lifecycle.PodAdmitResult
-		qosClass v1.PodQOSClass
-		expected bool
-	}{
-		{
-			name:     "QOSClass set as Guaranteed",
-			result:   lifecycle.PodAdmitResult{},
-			qosClass: v1.PodQOSGuaranteed,
-			expected: true,
-		},
-		{
-			name:     "QOSClass set as Burstable",
-			result:   lifecycle.PodAdmitResult{},
-			qosClass: v1.PodQOSBurstable,
-			expected: true,
-		},
-		{
-			name:     "QOSClass set as BestEffort",
-			result:   lifecycle.PodAdmitResult{},
-			qosClass: v1.PodQOSBestEffort,
-			expected: true,
-		},
-	}
-	fm := fakeManager{}
-	for _, tc := range tcases {
-		podAttr := lifecycle.PodAdmitAttributes{}
-		pod := v1.Pod{}
-		pod.Status.QOSClass = tc.qosClass
-		podAttr.Pod = &pod
-		actual := fm.Admit(&podAttr)
-		if reflect.DeepEqual(actual, tc.result) {
-			t.Errorf("Error occurred, expected Admit in result to be %v got %v", tc.result, actual.Admit)
+		if len1-len2 != 1 {
+			t.Errorf("Remove Pod resulted in error")
 		}
 	}
+
 }

--- a/pkg/kubelet/cm/topologymanager/topology_manager_test.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager_test.go
@@ -18,12 +18,12 @@ package topologymanager
 
 import (
 	"fmt"
-	"reflect"
+
 	"strings"
 	"testing"
 
 	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
+
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 )
@@ -143,29 +143,6 @@ func (m *mockHintProvider) Allocate(pod *v1.Pod, container *v1.Container) error 
 	return nil
 }
 
-func TestGetAffinity(t *testing.T) {
-	tcases := []struct {
-		name          string
-		containerName string
-		podUID        string
-		expected      TopologyHint
-	}{
-		{
-			name:          "case1",
-			containerName: "nginx",
-			podUID:        "0aafa4c4-38e8-11e9-bcb1-a4bf01040474",
-			expected:      TopologyHint{},
-		},
-	}
-	for _, tc := range tcases {
-		mngr := manager{}
-		actual := mngr.GetAffinity(tc.podUID, tc.containerName)
-		if !reflect.DeepEqual(actual, tc.expected) {
-			t.Errorf("Expected Affinity in result to be %v, got %v", tc.expected, actual)
-		}
-	}
-}
-
 type mockPolicy struct {
 	nonePolicy
 	ph []map[string][]TopologyHint
@@ -176,76 +153,7 @@ func (p *mockPolicy) Merge(providersHints []map[string][]TopologyHint) (Topology
 	return TopologyHint{}, true
 }
 
-func TestAddContainer(t *testing.T) {
-	testCases := []struct {
-		name        string
-		containerID string
-		podUID      types.UID
-	}{
-		{
-			name:        "Case1",
-			containerID: "nginx",
-			podUID:      "0aafa4c4-38e8-11e9-bcb1-a4bf01040474",
-		},
-		{
-			name:        "Case2",
-			containerID: "Busy_Box",
-			podUID:      "b3ee37fc-39a5-11e9-bcb1-a4bf01040474",
-		},
-	}
-	mngr := manager{}
-	mngr.podMap = make(map[string]string)
-	for _, tc := range testCases {
-		pod := v1.Pod{}
-		pod.UID = tc.podUID
-		err := mngr.AddContainer(&pod, tc.containerID)
-		if err != nil {
-			t.Errorf("Expected error to be nil but got: %v", err)
-		}
-		if val, ok := mngr.podMap[tc.containerID]; ok {
-			if reflect.DeepEqual(val, pod.UID) {
-				t.Errorf("Error occurred")
-			}
-		} else {
-			t.Errorf("Error occurred, Pod not added to podMap")
-		}
-	}
-}
 
-func TestRemoveContainer(t *testing.T) {
-	testCases := []struct {
-		name        string
-		containerID string
-		podUID      types.UID
-	}{
-		{
-			name:        "Case1",
-			containerID: "nginx",
-			podUID:      "0aafa4c4-38e8-11e9-bcb1-a4bf01040474",
-		},
-		{
-			name:        "Case2",
-			containerID: "Busy_Box",
-			podUID:      "b3ee37fc-39a5-11e9-bcb1-a4bf01040474",
-		},
-	}
-	var len1, len2 int
-	mngr := manager{}
-	mngr.podMap = make(map[string]string)
-	for _, tc := range testCases {
-		mngr.podMap[tc.containerID] = string(tc.podUID)
-		len1 = len(mngr.podMap)
-		err := mngr.RemoveContainer(tc.containerID)
-		len2 = len(mngr.podMap)
-		if err != nil {
-			t.Errorf("Expected error to be nil but got: %v", err)
-		}
-		if len1-len2 != 1 {
-			t.Errorf("Remove Pod resulted in error")
-		}
-	}
-
-}
 
 func TestAddHintProvider(t *testing.T) {
 	var len1 int
@@ -549,7 +457,7 @@ func TestAdmit(t *testing.T) {
 		},
 	}
 	for _, tc := range tcases {
-		pth := &PodTopologyHints{}
+		pth := PodTopologyHints{}
 		ctnScope := &containerScope{
 			scope{
 				hintProviders:    tc.hp,
@@ -562,7 +470,6 @@ func TestAdmit(t *testing.T) {
 		mngr1 := manager{
 			policy:           tc.policy,
 			scope:            ctnScope,
-			podTopologyHints: PodTopologyHints{},
 		}
 
 		pScope := &podScope{
@@ -577,7 +484,6 @@ func TestAdmit(t *testing.T) {
 		mngr2 := manager{
 			policy:           tc.policy,
 			scope:            pScope,
-			podTopologyHints: PodTopologyHints{},
 		}
 
 		pod := &v1.Pod{


### PR DESCRIPTION
List of changes:
- scopes moved to separate files: `scope_container.go`, `scope_pod.go`, `scope.go`
- pod/container admission is now a part of a scope 
- hint providers are registered inside a scope 